### PR TITLE
Fixed a potential bug

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -91,7 +91,7 @@ public class PullToRefresh: NSObject {
             let refreshViewHeight = refreshView.frame.size.height
             
             switch offset {
-            case 0: state = .Inital
+            case 0 where (state != .Loading): state = .Inital
             case -refreshViewHeight...0 where (state != .Loading && state != .Finished):
                 state = .Releasing(progress: -offset / refreshViewHeight)
             case -1000...(-refreshViewHeight):


### PR DESCRIPTION
When the PullToRefresh object is at a state .Load and the user quickly push up the scrollview, it could make the Offset in function observeValueForKeyPath be 0, which would accidentally set state to .Initial. If  this is the case, it would finally make the scrollview have an incorrect contentinset(set during the state .Load)

To avoid this bug, we should get rid of .Loading state when we judge the offset value.
