### PR TITLE
Added ability to set custom refresh activation height

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -28,7 +28,7 @@ public class PullToRefresh: NSObject {
     private let animator: RefreshViewAnimator
     
     // MARK: - ScrollView & Observing
-    
+
     private var scrollViewDefaultInsets = UIEdgeInsetsZero
     weak var scrollView: UIScrollView? {
         willSet {
@@ -41,7 +41,7 @@ public class PullToRefresh: NSObject {
             }
         }
     }
-    
+
     private func addScrollViewObserving() {
         scrollView?.addObserver(self, forKeyPath: contentOffsetKeyPath, options: .Initial, context: &KVOContext)
     }
@@ -49,7 +49,7 @@ public class PullToRefresh: NSObject {
     private func removeScrollViewObserving() {
         scrollView?.removeObserver(self, forKeyPath: contentOffsetKeyPath, context: &KVOContext)
     }
-    
+
     // MARK: - State
     
     var state: State = .Inital {
@@ -76,9 +76,9 @@ public class PullToRefresh: NSObject {
                 UIView.animateWithDuration(1, delay: hideDelay, usingSpringWithDamping: 0.4, initialSpringVelocity: 0.8, options: UIViewAnimationOptions.CurveLinear, animations: {
                     self.scrollView?.contentInset = self.scrollViewDefaultInsets
                     self.scrollView?.contentOffset.y = -self.scrollViewDefaultInsets.top
-                    }, completion: { finished in
-                        self.addScrollViewObserving()
-                        self.state = .Inital
+                }, completion: { finished in
+                    self.addScrollViewObserving()
+                    self.state = .Inital
                 })
             default: break
             }
@@ -102,7 +102,7 @@ public class PullToRefresh: NSObject {
     }
     
     // MARK: KVO
-    
+
     private var KVOContext = "PullToRefreshKVOContext"
     private let contentOffsetKeyPath = "contentOffset"
     private var previousScrollViewOffset: CGPoint = CGPointZero
@@ -142,8 +142,8 @@ public class PullToRefresh: NSObject {
             Int64(0.27 * Double(NSEC_PER_SEC)))
         
         dispatch_after(delayTime, dispatch_get_main_queue(), {
-            self.state = State.Loading
-        })
+                self.state = State.Loading
+            })
     }
     
     func endRefreshing() {
@@ -239,7 +239,7 @@ class DefaultViewAnimator: RefreshViewAnimator {
         case .Inital: refreshView.activicyIndicator?.stopAnimating()
         case .Releasing(let progress):
             refreshView.activicyIndicator?.hidden = false
-            
+
             var transform = CGAffineTransformIdentity
             transform = CGAffineTransformScale(transform, progress, progress);
             transform = CGAffineTransformRotate(transform, 3.14 * progress * 2);

--- a/PullToRefresh/UIScrollView+PullToRefresh.swift
+++ b/PullToRefresh/UIScrollView+PullToRefresh.swift
@@ -33,6 +33,7 @@ public extension UIScrollView {
         
         let view = pullToRefresh.refreshView
         view.frame = CGRectMake(0, -view.frame.size.height, self.frame.size.width, view.frame.size.height)
+        view.autoresizingMask = UIViewAutoresizing.FlexibleWidth
         self.addSubview(view)
         self.sendSubviewToBack(view)
     }

--- a/PullToRefresher.podspec
+++ b/PullToRefresher.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
 
 
-  s.source       = { :git => "https://github.com/madnik/PullToRefresh.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/Yalantis/PullToRefresh.git", :tag => s.version.to_s }
   s.source_files = "PullToRefresh/*.swift"
   s.module_name  = "PullToRefresh"
   s.requires_arc = true

--- a/PullToRefresher.podspec
+++ b/PullToRefresher.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
 
 
-  s.source       = { :git => "https://github.com/Yalantis/PullToRefresh.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/madnik/PullToRefresh.git", :tag => s.version.to_s }
   s.source_files = "PullToRefresh/*.swift"
   s.module_name  = "PullToRefresh"
   s.requires_arc = true


### PR DESCRIPTION
Currently refresh activation when pulling beyond the refresh view height. Now we can set custom height which defaults to refreshview height. This will enable creating more refresh views where height of the view not effecting the refresh activation.
