### PR TITLE
Allows default animations to be customized

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -180,7 +180,13 @@ public func ==(a: State, b: State) -> Bool {
 
 public class DefaultRefreshView: UIView {
     private(set) var activicyIndicator: UIActivityIndicatorView!
-    
+
+    public var height: CGFloat = 40 {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
@@ -192,7 +198,7 @@ public class DefaultRefreshView: UIView {
     }
     
     private func commonInit() {
-        frame = CGRectMake(frame.origin.x, frame.origin.y, frame.width, 40)
+        frame = CGRectMake(frame.origin.x, frame.origin.y, frame.width, height)
     }
     
     public override func layoutSubviews() {
@@ -213,7 +219,7 @@ public class DefaultRefreshView: UIView {
     
     private func setupFrameInSuperview(newSuperview: UIView?) {
         if let superview = newSuperview {
-            frame = CGRectMake(frame.origin.x, frame.origin.y, superview.frame.width, 40)
+            frame = CGRectMake(frame.origin.x, frame.origin.y, superview.frame.width, height)
         }
     }
     

--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -58,11 +58,11 @@ public class PullToRefresh: NSObject {
                     scrollView.contentOffset = previousScrollViewOffset
                     scrollView.bounces = false
                     animator.animateLoading(animations: {
-                            let insets = self.refreshView.frame.height + self.scrollViewDefaultInsets.top
-                            scrollView.contentInset.top = insets
-                            scrollView.contentOffset = CGPointMake(scrollView.contentOffset.x, -insets)
-                        }, completion: { _ in
-                            scrollView.bounces = true
+                        let insets = self.refreshView.frame.height + self.scrollViewDefaultInsets.top
+                        scrollView.contentInset.top = insets
+                        scrollView.contentOffset = CGPointMake(scrollView.contentOffset.x, -insets)
+                    }, completion: { _ in
+                        scrollView.bounces = true
                     })
                     
                     action?()
@@ -70,11 +70,11 @@ public class PullToRefresh: NSObject {
             case .Finished:
                 removeScrollViewObserving()
                 animator.animateFinished(animations: {
-                        self.scrollView?.contentInset = self.scrollViewDefaultInsets
-                        self.scrollView?.contentOffset.y = -self.scrollViewDefaultInsets.top
-                    }, completion: { _ in
-                        self.addScrollViewObserving()
-                        self.state = .Inital
+                    self.scrollView?.contentInset = self.scrollViewDefaultInsets
+                    self.scrollView?.contentOffset.y = -self.scrollViewDefaultInsets.top
+                }, completion: { _ in
+                    self.addScrollViewObserving()
+                    self.state = .Inital
                 })
             default: break
             }

--- a/PullToRefreshDemo/ViewController.swift
+++ b/PullToRefreshDemo/ViewController.swift
@@ -17,7 +17,18 @@ class ViewController: UIViewController {
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
 
-        tableView.addPullToRefresh(PullToRefresh(), action: { [weak self] in
+        let pullToRefresh = PullToRefresh()
+
+        // Uncomment to view simple animation customizations
+//        let refreshView = DefaultRefreshView()
+//        let animator = DefaultViewAnimator(refreshView: refreshView)
+//        animator.loadingAnimationDuration = 0.6
+//        animator.finishedAnimationDuration = 2.0
+//        animator.finishedAnimationSpringVelocity = 1.6
+//
+//        let customPullToRefresh = PullToRefresh(refreshView: refreshView, animator: animator)
+
+        tableView.addPullToRefresh(pullToRefresh, action: { [weak self] in
             let delayTime = dispatch_time(DISPATCH_TIME_NOW,
                 Int64(2 * Double(NSEC_PER_SEC)))
             dispatch_after(delayTime, dispatch_get_main_queue()) {

--- a/PullToRefreshDemo/ViewController.swift
+++ b/PullToRefreshDemo/ViewController.swift
@@ -19,8 +19,10 @@ class ViewController: UIViewController {
 
         let pullToRefresh = PullToRefresh()
 
-        // Uncomment to view simple animation customizations
+        // Uncomment to view simple customizations
 //        let refreshView = DefaultRefreshView()
+//        refreshView.height = 60
+//
 //        let animator = DefaultViewAnimator(refreshView: refreshView)
 //        animator.loadingAnimationDuration = 0.6
 //        animator.finishedAnimationDuration = 2.0


### PR DESCRIPTION
The intent of this pull request is to support the following use case of the component:

As a user of `PullToRefresh` I wish to be able to modify behaviour of the default implementations without needing to re-implement `DefaultRefreshView` or `DefaultViewAnimator`.
Example 1: I wish to change the duration of the existing position loading animation from 0.3 to 0.5. 
Example 2: I wish to modify the hide animation so that it is `curveEaseIn`, rather than the existing spring.
Example 3: I wish to change the height of the `DefaultRefreshView` from 40 to 60.

Example 1 is now possible through setting `loadingAnimationDuration` property on an instance of `DefaultViewAnimator`. 
Example 2 is now possible through subclassing `DefaultViewAnimator` and overriding `animateFinished(animations:completion:)`
Example 3 is now possible through setting the `height` property on an instance of `DefaultRefreshView`. 
