### PR TITLE
added semaphore around add/remove observing to protect agains crash

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -41,16 +41,16 @@ public class PullToRefresh: NSObject {
     }
     
 	private func addScrollViewObserving() {
-		if ( !observing ) {
+		if let scrollView = scrollView where (observing == false) {
 			observing = true;
-			scrollView?.addObserver(self, forKeyPath: contentOffsetKeyPath, options: .Initial, context: &KVOContext)
+			scrollView.addObserver(self, forKeyPath: contentOffsetKeyPath, options: .Initial, context: &KVOContext)
 		}
 	}
 	
 	private func removeScrollViewObserving() {
-		if ( observing ) {
+		if let scrollView = scrollView where (observing == true) {
 			observing = false;
-			scrollView?.removeObserver(self, forKeyPath: contentOffsetKeyPath, context: &KVOContext)
+			scrollView.removeObserver(self, forKeyPath: contentOffsetKeyPath, context: &KVOContext)
 		}
 	}
 

--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -21,7 +21,8 @@ public class PullToRefresh: NSObject {
 
     let refreshView: UIView
     var action: (() -> ())?
-    
+	var observing = false
+ 
     private let animator: RefreshViewAnimator
     
     // MARK: - ScrollView & Observing
@@ -39,13 +40,19 @@ public class PullToRefresh: NSObject {
         }
     }
     
-    private func addScrollViewObserving() {
-        scrollView?.addObserver(self, forKeyPath: contentOffsetKeyPath, options: .Initial, context: &KVOContext)
-    }
-    
-    private func removeScrollViewObserving() {
-        scrollView?.removeObserver(self, forKeyPath: contentOffsetKeyPath, context: &KVOContext)
-    }
+	private func addScrollViewObserving() {
+		if ( !observing ) {
+			observing = true;
+			scrollView?.addObserver(self, forKeyPath: contentOffsetKeyPath, options: .Initial, context: &KVOContext)
+		}
+	}
+	
+	private func removeScrollViewObserving() {
+		if ( observing ) {
+			observing = false;
+			scrollView?.removeObserver(self, forKeyPath: contentOffsetKeyPath, context: &KVOContext)
+		}
+	}
 
     // MARK: - State
     


### PR DESCRIPTION
After receiving a crash Issue #33 I added a protection wrapper around add/remove observing. 
