### PR TITLE
Query the state of the pull to refresh view

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -47,7 +47,7 @@ public class PullToRefresh: NSObject {
     
     // MARK: - State
     
-    private (set) var state: State = .Initial {
+    public private(set) var state: State = .Initial {
         didSet {
             animator.animateState(state)
             switch state {

--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -47,7 +47,7 @@ public class PullToRefresh: NSObject {
     
     // MARK: - State
     
-    var state: State = .Initial {
+    private (set) var state: State = .Initial {
         didSet {
             animator.animateState(state)
             switch state {


### PR DESCRIPTION
This is useful when you need to differentiate between full screen loading views and pull to refresh without needing to include local state.
