### PR TITLE
Center activity indicator horizontally when using auto layout (Swift 2)

### DIFF
--- a/PullToRefresh/DefaultRefreshView.swift
+++ b/PullToRefresh/DefaultRefreshView.swift
@@ -28,6 +28,7 @@ class DefaultRefreshView: UIView {
     
     override func willMoveToSuperview(newSuperview: UIView?) {
         super.willMoveToSuperview(newSuperview)
+        centerActivityIndicator()
         setupFrameInSuperview(superview)
     }
 }


### PR DESCRIPTION
The activity indicator view in the `DefaultRefreshView` is not entered horizontally.
I'm experiencing this when using auto layout.
This PR fixes it.
Thanks for the great control.
