### PR TITLE
Center activity indicator horizontally when using auto layout (Swift 3)

### DIFF
--- a/PullToRefresh/DefaultRefreshView.swift
+++ b/PullToRefresh/DefaultRefreshView.swift
@@ -25,6 +25,7 @@ class DefaultRefreshView: UIView {
     
     override func willMove(toSuperview newSuperview: UIView?) {
         super.willMove(toSuperview: newSuperview)
+        centerActivityIndicator()
         setupFrame(in: superview)
     }
 }


### PR DESCRIPTION
_TLTR: the same as https://github.com/Yalantis/PullToRefresh/pull/45 but for Swift 3 branch._

The activity indicator view in the `DefaultRefreshView` is not entered horizontally.
I'm experiencing this when using auto layout.
This PR fixes it.
