### PR TITLE
Callback now indicates if action was initiated by user or not

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -24,7 +24,8 @@ open class PullToRefresh: NSObject {
     open var springDamping: CGFloat = 0.4
     open var initialSpringVelocity: CGFloat = 0.8
     open var animationOptions: UIViewAnimationOptions = [.curveLinear]
-
+    open var refreshViewHeight: CGFloat = 0
+    
     let refreshView: UIView
     var action: ActionType?
     
@@ -74,6 +75,7 @@ open class PullToRefresh: NSObject {
     
     public init(refreshView: UIView, animator: RefreshViewAnimator, height: CGFloat, position: Position) {
         self.refreshView = refreshView
+        self.refreshViewHeight = height
         self.animator = animator
         self.position = position
     }

--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -15,6 +15,8 @@ public enum Position {
 
 open class PullToRefresh: NSObject {
     
+    public typealias ActionType = ((_ userInitiated: Bool) -> ())
+    
     open var position: Position = .top
     
     open var animationDuration: TimeInterval = 1
@@ -24,7 +26,7 @@ open class PullToRefresh: NSObject {
     open var animationOptions: UIViewAnimationOptions = [.curveLinear]
 
     let refreshView: UIView
-    var action: (() -> ())?
+    var action: ActionType?
     
     fileprivate var isObserving = false
     fileprivate let animator: RefreshViewAnimator
@@ -50,9 +52,9 @@ open class PullToRefresh: NSObject {
         didSet {
             animator.animate(state)
             switch state {
-            case .loading:
-                if oldValue != .loading {
-                    animateLoadingState()
+            case .loading(let userInitiated):
+                if oldValue != .loading(userInitiated: false) {
+                    animateLoadingState(userInitiated: userInitiated)
                 }
                 
             case .finished:
@@ -113,14 +115,14 @@ open class PullToRefresh: NSObject {
             let refreshViewHeight = refreshView.frame.size.height
             
             switch offset {
-            case 0 where (state != .loading): state = .initial
-            case -refreshViewHeight...0 where (state != .loading && state != .finished):
+            case 0 where (state != .loading(userInitiated: false)): state = .initial
+            case -refreshViewHeight...0 where (state != .loading(userInitiated: false) && state != .finished):
                 state = .releasing(progress: -offset / refreshViewHeight)
                 
             case -1000...(-refreshViewHeight):
                 if state == .releasing(progress: 1) && scrollView?.isDragging == false {
-                    state = .loading
-                } else if state != .loading && state != .finished {
+                    state = .loading(userInitiated: true)
+                } else if state != .loading(userInitiated: false) && state != .finished {
                     state = .releasing(progress: 1)
                 }
             default: break
@@ -186,12 +188,12 @@ extension PullToRefresh {
         scrollView?.setContentOffset(CGPoint(x: 0, y: offsetY), animated: true)
         let delayTime = DispatchTime.now() + Double(Int64(0.27 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
         DispatchQueue.main.asyncAfter(deadline: delayTime) { [weak self] in
-            self?.state = .loading
+            self?.state = .loading(userInitiated: false)
         }
     }
     
     func endRefreshing() {
-        if state == .loading {
+        if state == .loading(userInitiated: false) {
             state = .finished
         }
     }
@@ -200,7 +202,7 @@ extension PullToRefresh {
 // MARK: - Animate scroll view
 private extension PullToRefresh {
     
-    func animateLoadingState() {
+    func animateLoadingState(userInitiated: Bool) {
         guard let scrollView = scrollView else {
             return
         }
@@ -226,7 +228,7 @@ private extension PullToRefresh {
             }
         )
         
-        action?()
+        action?(userInitiated)
     }
     
     func animateFinishedState() {

--- a/PullToRefresh/State.swift
+++ b/PullToRefresh/State.swift
@@ -12,7 +12,7 @@ public enum State: Equatable, CustomStringConvertible {
     
     case initial
     case releasing(progress: CGFloat)
-    case loading
+    case loading(userInitiated: Bool)
     case finished
     
     public var description: String {

--- a/PullToRefresh/UIScrollView+PullToRefresh.swift
+++ b/PullToRefresh/UIScrollView+PullToRefresh.swift
@@ -33,7 +33,7 @@ public extension UIScrollView {
         }
     }
     
-    public func addPullToRefresh(_ pullToRefresh: PullToRefresh, action: @escaping () -> ()) {
+    public func addPullToRefresh(_ pullToRefresh: PullToRefresh, action: @escaping PullToRefresh.ActionType) {
         pullToRefresh.scrollView = self
         pullToRefresh.action = action
         

--- a/PullToRefreshDemo/ViewController.swift
+++ b/PullToRefreshDemo/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController {
 private extension ViewController {
     
     func setupPullToRefresh() {
-        tableView.addPullToRefresh(PullToRefresh()) { [weak self] in
+        tableView.addPullToRefresh(PullToRefresh()) { [weak self] (userInitiated) in
             let delayTime = DispatchTime.now() + Double(Int64(2 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
             DispatchQueue.main.asyncAfter(deadline: delayTime) {
                 self?.dataSourceCount = PageSize
@@ -42,7 +42,7 @@ private extension ViewController {
             }
         }
         
-        tableView.addPullToRefresh(PullToRefresh(position: .bottom)) { [weak self] in
+        tableView.addPullToRefresh(PullToRefresh(position: .bottom)) { [weak self] (userInitiated) in
             let delayTime = DispatchTime.now() + Double(Int64(2 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
             DispatchQueue.main.asyncAfter(deadline: delayTime) {
                 self?.dataSourceCount += PageSize


### PR DESCRIPTION
Following ticket Yalantis/PullToRefresh/issues/58 

I'm not sure about the best practice to compare the enum (as I added a boolean inside), so I followed what was done for the progress case.

I think this feature would be very helpful. But it breaks some code for any current implementation, so if shouldn't be included in a minor version.

Thanks,
Vincent