### PR TITLE
Remove warnings when using swift 3.1, xcode 8.3

### DIFF
--- a/PullToRefresh/DefaultViewAnimator.swift
+++ b/PullToRefresh/DefaultViewAnimator.swift
@@ -26,7 +26,7 @@ class DefaultViewAnimator: RefreshViewAnimator {
             
             var transform = CGAffineTransform.identity
             transform = transform.scaledBy(x: progress, y: progress)
-            transform = transform.rotated(by: CGFloat(M_PI) * progress * 2)
+            transform = transform.rotated(by: CGFloat(Double.pi) * progress * 2)
             refreshView.activityIndicator.transform = transform
             
         case .loading:

--- a/PullToRefresh/UIScrollView+PullToRefresh.swift
+++ b/PullToRefresh/UIScrollView+PullToRefresh.swift
@@ -54,7 +54,7 @@ public extension UIScrollView {
             originY = contentSize.height
         }
         
-        view.frame = CGRect(x: 0, y: originY, width: frame.width, height: view.frame.height)
+        view.frame = CGRect(x: 0, y: originY, width: UIScreen.main.bounds.size.width, height: view.frame.height)
         
         addSubview(view)
         sendSubview(toBack: view)

--- a/PullToRefresh/UIScrollView+PullToRefresh.swift
+++ b/PullToRefresh/UIScrollView+PullToRefresh.swift
@@ -54,7 +54,7 @@ public extension UIScrollView {
             originY = contentSize.height
         }
         
-        view.frame = CGRect(x: 0, y: originY, width: UIScreen.main.bounds.size.width, height: view.frame.height)
+        view.frame = CGRect(x: 0, y: originY, width: frame.width, height: view.frame.height)
         
         addSubview(view)
         sendSubview(toBack: view)


### PR DESCRIPTION
Minor minor change to remove warnings when building in xcode 8.3 and swift 3.1.