### PR TITLE
Bump pod version

### DIFF
--- a/PullToRefresher.podspec
+++ b/PullToRefresher.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "PullToRefresher"
-  s.version      = "2.0.2"
+  s.version      = "2.1"
   s.summary      = "This component implements pure pull-to-refresh logic and you can use it for developing your own pull-to-refresh animations"
   s.homepage     = "http://yalantis.com/blog/how-we-built-customizable-pull-to-refresh-pull-to-cook-soup-animation/"
 


### PR DESCRIPTION
It has been over a year since the Podspec version has been incremented.

In that time, 13 PRs have been merged into `master` and also a handful of other fixes and commits.

But, since the Podspec version hasn't been incremented, nobody using Cocoapods to get PullToRefresh have received _any_ of these updates (including myself). I personally need access to at least 2 bugs fixed by these PRs and have been manually managing this dependency, because of this.

The attached diff will increment the Pod version number so everyone will receive these updates.