### PR TITLE
UIRefreshControl-like behavior

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -275,7 +275,7 @@ private extension PullToRefresh {
                 case .top:
                     let insets = self.refreshView.frame.height + self.scrollViewDefaultInsets.top
                     scrollView.contentInset.top = insets
-                    let offsetY = self.defaultInsets.top + self.refreshView.frame.height
+                    let offsetY = self.scrollViewDefaultInsets.top + self.refreshView.frame.height
                     scrollView.contentOffset = CGPoint(x: scrollView.contentOffset.x, y: -offsetY)
                     
                 case .bottom:

--- a/PullToRefresh/State.swift
+++ b/PullToRefresh/State.swift
@@ -12,14 +12,14 @@ public enum State: Equatable, CustomStringConvertible {
     
     case initial
     case releasing(progress: CGFloat)
-    case loading
+    case loading(isDragging: Bool)
     case finished
     
     public var description: String {
         switch self {
         case .initial: return "Inital"
-        case .releasing(let progress): return "Releasing:\(progress)"
-        case .loading: return "Loading"
+        case .releasing(let progress): return "Releasing: \(progress)"
+        case .loading(let isDragging): return "Loading: \(isDragging)"
         case .finished: return "Finished"
         }
     }
@@ -28,9 +28,9 @@ public enum State: Equatable, CustomStringConvertible {
 public func ==(a: State, b: State) -> Bool {
     switch (a, b) {
     case (.initial, .initial): return true
-    case (.loading, .loading): return true
     case (.finished, .finished): return true
-    case (.releasing, .releasing): return true
+    case (.loading(let isDragging1), .loading(let isDragging2)) where isDragging1 == isDragging2: return true
+    case (.releasing(let progress1), .releasing(let progress2)) where abs(progress1 - progress2) < 0.01: return true
     default: return false
     }
 }

--- a/PullToRefresh/UIScrollView+PullToRefresh.swift
+++ b/PullToRefresh/UIScrollView+PullToRefresh.swift
@@ -67,7 +67,7 @@ public extension UIScrollView {
         sendSubview(toBack: view)
     }
     
-    func removePullToRefresh(at position: Position) {
+    func removePullToRefresh(at position: Position = .top) {
         switch position {
         case .top:
             topPullToRefresh?.refreshView.removeFromSuperview()
@@ -84,7 +84,7 @@ public extension UIScrollView {
         removePullToRefresh(at: .bottom)
     }
     
-    func startRefreshing(at position: Position) {
+    func startRefreshing(at position: Position = .top) {
         switch position {
         case .top:
             topPullToRefresh?.startRefreshing()
@@ -94,7 +94,7 @@ public extension UIScrollView {
         }
     }
     
-    func endRefreshing(at position: Position) {
+    func endRefreshing(at position: Position = .top) {
         switch position {
         case .top:
             topPullToRefresh?.endRefreshing()


### PR DESCRIPTION
Split loading state to one while dragging and after the user releases his finger. Now control starts animating and sends update request just after the user scrolls enough down while he is dragging. Both cases of releasing before finishing and after it.
Fixed loading animation (slight jumping) on iOS 11. 
Added .top default value to Position params