### PR TITLE
- Property to set top padding in some special cases

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -33,6 +33,7 @@ open class PullToRefresh: NSObject {
     open var initialSpringVelocity: CGFloat = 0.8
     open var animationOptions: UIViewAnimationOptions = [.curveLinear]
     open var shouldBeVisibleWhileScrolling: Bool = false
+    open var topPadding : CGFloat? = nil
     
     let refreshView: UIView
     var isEnabled: Bool = false {

--- a/PullToRefresh/UIScrollView+PullToRefresh.swift
+++ b/PullToRefresh/UIScrollView+PullToRefresh.swift
@@ -157,8 +157,7 @@ internal extension UIScrollView {
         case .bottom:
             originY = contentSize.height
         }
-        
-        let height = pullToRefresh.topPadding != nil ? view.frame.height + pullToRefresh.topPadding! : view.frame.height
+        let height = view.frame.height + (pullToRefresh.topPadding ?? 0)
         return CGRect(x: 0, y: originY, width: frame.width, height: height)
     }
 

--- a/PullToRefresh/UIScrollView+PullToRefresh.swift
+++ b/PullToRefresh/UIScrollView+PullToRefresh.swift
@@ -158,7 +158,8 @@ internal extension UIScrollView {
             originY = contentSize.height
         }
         
-        return CGRect(x: 0, y: originY, width: frame.width, height: view.frame.height)
+        let height = pullToRefresh.topPadding != nil ? view.frame.height + pullToRefresh.topPadding! : view.frame.height
+        return CGRect(x: 0, y: originY, width: frame.width, height: height)
     }
 
 }


### PR DESCRIPTION
- In my application i have a custom view over the top of my collection view, then when I added the pull to refresh, this was added just behind this custom view. 

If I'm added that property I can consider the padding just before added to the table view, and the refresher view will be showed completely.

This is the example:

### Without top padding
___
![withouttoppadding](https://user-images.githubusercontent.com/5713880/42391539-5887c1f6-8115-11e8-9817-15feb1392988.gif)

### With top padding
___
![toppadding](https://user-images.githubusercontent.com/5713880/42391546-61abbfbc-8115-11e8-82ee-1e1131b69413.gif)


