### PR TITLE
Fixed function name in deinit

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ tableView.addPullToRefresh(refresher) {
 
 ```swift
 deinit {
-tableView.removePullToRefresh(tableView.topPullToRefresh!)
+    tableView.removeAllPullToRefresh()
 }
 ```
 


### PR DESCRIPTION
Hello,

Currently, in the deinit function, this method was called, which is not found anymore.
```swift
tableView.removePullToRefresh(tableView.topPullToRefresh!)
``` 

The method was replaced with this one where position can be `.top` or `.bottom`.
```swift
func removePullToRefresh(at position: Position)
```

I replaced in the README this function `removePullToRefresh` with this one `removeAllPullToRefresh` which calls `removePullToRefresh` with `.top` and `.bottom` parameters.

Have a good day,
Cosmin